### PR TITLE
Added package.json, fixed Acorn paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/compile.js
+++ b/compile.js
@@ -1,6 +1,6 @@
 var utils = require("./utils.js");
 var infer = require("./infer.js").infer;
-var acorn_walk = require("acorn/util/walk");
+var acorn_walk = require("acorn/dist/walk");
 
 
 function getType(node) {

--- a/infer.js
+++ b/infer.js
@@ -1,5 +1,5 @@
 var utils = require("./utils.js");
-var acorn_walk = require("acorn/util/walk");
+var acorn_walk = require("acorn/dist/walk");
 
 function infer(node, forceUndefined) {
   // forceUndefined = treat unknown types as JsVars

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "acorn": "^1.0.3"
+  }
+}


### PR DESCRIPTION
This pull requests makes the compiler easier to setup by defining NPM dependencies in `package.json` like a normal Node project.

It appears Acorn had an internal update recently which changed some paths, so `acorn/utils/walk` is changed to `acorn/dist/walk`.

`node index.js` fails, but it did so before these changes anyway.
