### PR TITLE
put everything into .text section

### DIFF
--- a/inc/linker.ld
+++ b/inc/linker.ld
@@ -12,7 +12,7 @@ SECTIONS
     . = ALIGN(4);
     *(.entryPoint)
   }
-  /* Then code, then constants */
+  /* We put everything in .text section as we load everything into RAM as one binary string */
 
   .text :
   {
@@ -22,18 +22,9 @@ SECTIONS
     *(.rodata)
     *(.rodata*)
     . = ALIGN(4);
-  } >RAM
-
-  .data :
-  {
-    . = ALIGN(4);
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
-  } >RAM
-
-  .bss :
-  {
-    /* This is used by the startup in order to initialize the .bss secion */
+    . = ALIGN(4);
     *(.bss)
     *(.bss*)
     *(COMMON)


### PR DESCRIPTION
At runtime we load code + data as one binary string into ram so let's put everything into same section already by linker. This also fixes memory corruption  bug with uninitialized data in .bss section that is currently not included into binary string.

the `. = ALIGN(4);`  bits may not be needed between, but it won't hurt.